### PR TITLE
chore(VEH-2750): add dependabot-fix make target and workflow

### DIFF
--- a/.github/workflows/dependabot-make.yaml
+++ b/.github/workflows/dependabot-make.yaml
@@ -1,0 +1,20 @@
+name: Dependabot Make Fix
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - master
+
+jobs:
+  call-dependabot-make-fix:
+    permissions:
+      contents: write
+      id-token: write
+      pull-requests: write
+    uses: einride/github-actions/.github/workflows/reusable-dependabot-make.yaml@master
+    secrets:
+      einridebot_personal_access_token: ${{ secrets.EINRIDEBOT_PERSONAL_ACCESS_TOKEN }}

--- a/.sage/main.go
+++ b/.sage/main.go
@@ -26,6 +26,16 @@ func Default(ctx context.Context) error {
 	return nil
 }
 
+func DependabotFix(ctx context.Context) error {
+	sg.SerialDeps(
+		ctx,
+		Install,
+		Format,
+		GoFormat,
+	)
+	return nil
+}
+
 func Install(ctx context.Context) error {
 	sg.Logger(ctx).Println("installing dependencies...")
 	return sg.Command(ctx, "yarn", "install").Run()

--- a/Makefile
+++ b/Makefile
@@ -55,6 +55,10 @@ commitlint: $(sagefile)
 default: $(sagefile)
 	@$(sagefile) Default
 
+.PHONY: dependabot-fix
+dependabot-fix: $(sagefile)
+	@$(sagefile) DependabotFix
+
 .PHONY: format
 format: $(sagefile)
 	@$(sagefile) Format


### PR DESCRIPTION
Adds the Dependabot Fix workflow presented during the June 2025 hackathon. This make target and workflow will run make commands in order to attempt to fix errors in the dependabot PRs. We've already added is successfully to all @asset-intelligence owned repositories, but please let me know if it fails and we'll try to fix it.